### PR TITLE
add 1.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,14 @@ language: julia
 os:
   - linux
 julia:
-  - release
+  - 1.0
   - nightly
 matrix:
   allow_failures:
   - julia: nightly
 notifications:
   email: false
-# uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("Coulter"); Pkg.test("Coulter"; coverage=true)'
 after_success:
   # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("Coulter")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,7 @@
-julia 0.5
+julia 0.7
 FileIO
 KernelDensity
 Distributions
 DataStructures
-Compat 0.41.0
 Gadfly
 StatsBase

--- a/src/Coulter.jl
+++ b/src/Coulter.jl
@@ -4,12 +4,11 @@ module Coulter
 
     using KernelDensity
     using Distributions
-    using Compat
     using Gadfly
     using StatsBase
     using DataStructures
     import Base.-, Base.deepcopy
-    import Base.Dates.Second
+    using Dates: Second, DateTime
 
     export CoulterCounterRun, loadZ2, -, volume, diameter,
         extract_peak, extract_peak!, extract_peak_interval
@@ -20,7 +19,7 @@ module Coulter
     """
     A simplified representation of a coulter counter run
     """
-    type CoulterCounterRun
+    struct CoulterCounterRun
         filename::String
         sample::String
         timepoint::DateTime
@@ -50,7 +49,7 @@ module Coulter
     function loadZ2(filepath::String, sample::String; yvariable=:count)
         open(filepath) do s
             # split windows newlines if present
-            filebody = replace(readstring(s), "\r\n", "\n")
+            filebody = replace(read(s, String), "\r\n"=>"\n")
             # extract start time and date from body
             datetime = match(r"^StartTime= \d*\s*(?<time>\d*:\d*:\d*)\s*(?<date>\d*\s\w{3}\s\d{4})$"m, filebody)
             timepoint = DateTime("$(datetime[:date]) $(datetime[:time])", "dd uuu yyy HH:MM:SS")

--- a/src/Coulter.jl
+++ b/src/Coulter.jl
@@ -19,7 +19,7 @@ module Coulter
     """
     A simplified representation of a coulter counter run
     """
-    struct CoulterCounterRun
+    mutable struct CoulterCounterRun
         filename::String
         sample::String
         timepoint::DateTime

--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -137,7 +137,7 @@ function extract_peak!(run::CoulterCounterRun; folder="raw_coulter_graphs")
                                 Theme(default_color=colorant"gray", theme)))
     end
     # Round up to the nearest hundred fL that includes the lower 98th percentile of data
-    xlimmax = ceil(percentile(run.data, 98), -2)
+    xlimmax = ceil(percentile(run.data, 98), digits=-2)
     time = run.reltime != nothing ? run.reltime : run.timepoint
     p = plot(plot_peaks..., est, raw, theme,
              Coord.cartesian(xmin=50, xmax=xlimmax),

--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -32,7 +32,7 @@ Finds prominent peaks in `ys` and returns the values from `xs` corresponding to
 the location of these peaks. `minx` and `miny` can be used to exclude peaks that
 are too small in `x` or `y`.
 """
-function _find_peaks{T}(xs::Array{T}, ys::Array{T}; minx=310, miny=0.0005)
+function _find_peaks(xs::Array{T}, ys::Array{T}; minx=310, miny=0.0005) where T
     loc = zero(T) # location of an extremum
     width = zero(T) # width of an extremum
     sign = -1
@@ -71,7 +71,7 @@ function _find_peaks{T}(xs::Array{T}, ys::Array{T}; minx=310, miny=0.0005)
     for i in 2:length(is_peak)
         # This should only be triggered if a peak is not followed by a valley, or vice versa
         if !xor(is_peak[i], is_peak[i-1])
-            warn("Unable to establish prominence. Peak identification potentially flawed.")
+            @warn("Unable to establish prominence. Peak identification potentially flawed.")
             break
         end
     end
@@ -89,7 +89,7 @@ function _find_peaks{T}(xs::Array{T}, ys::Array{T}; minx=310, miny=0.0005)
         end
     end
     if length(peaks) > 1
-        warn("Multiple viable peaks identified: $(join(peaks, ", "))")
+        @warn("Multiple viable peaks identified: $(join(peaks, ", "))")
     end
     peaks
 end
@@ -106,7 +106,6 @@ theme = Theme(background_color=colorant"white", panel_stroke=colorant"black",
     major_label_font_size=14pt, minor_label_font_size=11pt,
     minor_label_color=colorant"black", major_label_color=colorant"black",
 key_title_color=colorant"black", key_label_color=colorant"black", key_title_font_size=13pt,
-    lowlight_opacity=0.3,
 key_label_font_size=10pt);
 
 function extract_peak!(run::CoulterCounterRun; folder="raw_coulter_graphs")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -4,13 +4,13 @@
 Repeats the items in the first vector by the corresponding number of
 times in the second vector. Essentially the inverse operation of `hist`
 """
-function repvec{T}(orig::Vector{T}, reps::Vector{Int})
+function repvec(orig::Vector{T}, reps::Vector{Int}) where T
     (length(orig) != length(reps)) && error("Provided vectors have to be of same length")
-    data = Array{T}(sum(reps))
+    data = Array{T}(undef, sum(reps))
     j = 1
     for i in 1:length(orig)
         if reps[i] > 0
-            data[j:(j+reps[i]-1)] = orig[i]
+            data[j:(j+reps[i]-1)] .= orig[i]
             j += reps[i]
         end
     end


### PR DESCRIPTION
This requires Gadfly 1.0 support to be tagged before the tests will
pass. Drops support for 0.6